### PR TITLE
create the faceted graphs with the interactivity

### DIFF
--- a/src/trial.py
+++ b/src/trial.py
@@ -7,7 +7,9 @@ import vega_datasets as vega_datasets
 from dash.dependencies import Input, Output, State
 
 app = dash.Dash(__name__, assets_folder='assets', external_stylesheets=[dbc.themes.BOOTSTRAP])
+
 df = vega_datasets.data.barley()
+
 body = dbc.Container(
     [
         dbc.Row(
@@ -77,6 +79,17 @@ body = dbc.Container(
                             id='yield_per_site',
                             height='450',
                             width='450',
+                            style={'border-width': '0px', 'overflowX': 'scroll'}
+                        )
+                    ]
+                ),
+                dbc.Col(
+                    [
+                        html.Iframe(
+                            sandbox='allow-scripts',
+                            id='yield_per_site_per_variety',
+                            height='450',
+                            width='9000',
                             style={'border-width': '0px', 'overflowX': 'scroll'}
                         )
                     ]
@@ -177,6 +190,108 @@ def toggle_left(n_left, is_open):
     if n_left:
         return not is_open
     return is_open
+
+@app.callback(
+    Output('yield_per_site_per_variety', 'srcDoc'),
+    [Input('year_selector', 'value'), 
+    Input('site_selector', 'value'), 
+    Input('variety_selector', 'value')])
+def make_yield_per_site_per_variety(year, site, variety):
+    if year == 'both':
+        year_temp = [1931, 1932]
+    else:
+        year_temp = [year]
+
+    if not isinstance(site, list):
+        site_temp = list(site)
+    else:
+        site_temp = site
+
+    if not isinstance(variety, list):
+        variety_temp = list(variety)
+    else:
+        variety_temp = variety
+    
+    df_temp = df[df['year'].isin(year_temp)]
+    df_temp = df_temp[df_temp['variety'].isin(variety_temp)]
+
+    my_graphs = []
+
+    for sites in site_temp:
+        df_temp_site = df_temp[df_temp['site'] == sites]
+
+        df_max = (df_temp_site.drop(columns=['year'])
+                         .groupby('variety')
+                         .agg('sum')
+                         .sort_values('yield', ascending=False)
+                         .reset_index()
+                 )
+
+        my_max = df_max['variety'][0]
+
+        chart = alt.Chart(df_temp_site, width=600).mark_bar().encode(
+        alt.X("variety:N", 
+            title= sites,
+            sort=alt.EncodingSortField(field="yield", op="sum", order='ascending'),
+            axis = alt.Axis(labelAngle=45)),
+        alt.Y("yield:Q",
+            title = "Yield (kg/hectare)"),
+        color=alt.condition(
+            alt.datum.variety == my_max, 
+            alt.value('orange'),     
+            alt.value('steelblue')),
+        tooltip=['site', 'yield', 'variety', 'year']
+        ).interactive()
+
+        my_graphs.append(chart)
+    
+    if len(my_graphs) == 1:
+        my_chart = my_graphs[0]
+        my_chart = my_chart.configure_title(fontSize=18
+        ).configure_axis(
+        labelFontSize=10, 
+        titleFontSize=12
+        ).properties(title = "Yields for the selected varieties for the selected sites").configure_title(fontSize=25)
+    elif len(my_graphs) == 2:
+        my_chart = alt.hconcat(my_graphs[0], my_graphs[1]).configure_title(fontSize=18
+        ).configure_axis(
+        labelFontSize=10, 
+        titleFontSize=12
+        ).properties(title = "Yields for the selected varieties for the selected sites").configure_title(fontSize=25)
+    elif len(my_graphs) == 3:
+        my_chart = alt.hconcat(my_graphs[0], my_graphs[1], my_graphs[2]).configure_title(fontSize=18
+        ).configure_axis(
+        labelFontSize=10, 
+        titleFontSize=12
+        ).properties(title = "Yields for the selected varieties for the selected sites").configure_title(fontSize=25)
+    elif len(my_graphs) == 4:
+        my_chart = alt.vconcat(alt.hconcat(my_graphs[0], my_graphs[1]), 
+                              alt.hconcat(my_graphs[2], my_graphs[3])
+        ).configure_title(fontSize=18
+        ).configure_axis(
+        labelFontSize=10, 
+        titleFontSize=12
+        ).properties(title = "Yields for the selected varieties for the selected sites").configure_title(fontSize=25)
+    elif len(my_graphs) == 5:
+        my_chart = alt.vconcat(alt.hconcat(my_graphs[0], my_graphs[1], my_graphs[2]), 
+                              alt.hconcat(my_graphs[3], my_graphs[4])
+        ).configure_title(fontSize=18
+        ).configure_axis(
+        labelFontSize=10, 
+        titleFontSize=12
+        ).properties(title = "Yields for the selected varieties for the selected sites").configure_title(fontSize=25)
+    elif len(my_graphs) == 6:
+        my_chart = alt.vconcat(alt.hconcat(my_graphs[0], my_graphs[1], my_graphs[2]), 
+                              alt.hconcat(my_graphs[3], my_graphs[4], my_graphs[5])
+        ).configure_title(fontSize=18
+        ).configure_axis(
+        labelFontSize=10, 
+        titleFontSize=12
+        ).properties(title = "Yields for the selected varieties for the selected sites").configure_title(fontSize=25)
+    else : 
+        my_chart = alt.Chart()
+
+    return my_chart.to_html()
 
 if __name__ == '__main__':
     app.run_server(debug=True)

--- a/src/trial.py
+++ b/src/trial.py
@@ -179,6 +179,8 @@ def make_yield_per_site(year, site, variety):
         labelFontSize=11, 
         titleFontSize=13)
 
+
+
     return chart.to_html()
 
 @app.callback(
@@ -221,7 +223,7 @@ def make_yield_per_site_per_variety(year, site, variety):
         df_temp_site = df_temp[df_temp['site'] == sites]
 
         df_max = (df_temp_site.drop(columns=['year'])
-                         .groupby('variety')
+                         .groupby(['variety', 'site'])
                          .agg('sum')
                          .sort_values('yield', ascending=False)
                          .reset_index()
@@ -229,7 +231,7 @@ def make_yield_per_site_per_variety(year, site, variety):
 
         my_max = df_max['variety'][0]
 
-        chart = alt.Chart(df_temp_site, width=600).mark_bar().encode(
+        chart = alt.Chart(df_max, width=600).mark_bar().encode(
         alt.X("variety:N", 
             title= sites,
             sort=alt.EncodingSortField(field="yield", op="sum", order='ascending'),
@@ -240,8 +242,9 @@ def make_yield_per_site_per_variety(year, site, variety):
             alt.datum.variety == my_max, 
             alt.value('orange'),     
             alt.value('steelblue')),
-        tooltip=['site', 'yield', 'variety', 'year']
+        tooltip=['site', 'yield', 'variety']
         ).interactive()
+
 
         my_graphs.append(chart)
     


### PR DESCRIPTION
I created the third graph of the bashboard, which is the faceted graph that shows the yield for the selected years and for the selected varieties, for each selected site. The plots are interactive so when your mouse is above a bar, it will show the yield, the variety, the site and the year. When the user selects the two years, the values of the yield are not separated on the plot, but when the user moves the mouse from the top to the bottom of the bar, he/she will see the values of the yield for the 2 years.